### PR TITLE
Fix a bug in the corpus preprocessor, which changes dependency labels

### DIFF
--- a/src/kyoto_reader/scripts/template.mk
+++ b/src/kyoto_reader/scripts/template.mk
@@ -31,9 +31,9 @@ $(ORIG_KNP_DONE): $(CORPUS_KNPS)
 .PHONY: add-feats
 add-feats: $(OUT_KNPS)
 
-# knp -read-feature
+# knp -dpnd
 $(OUT_KNPS): $(OUT_KNP_DIR)/%.knp: $(ADD_SEMS_KNP_DIR)/%.knp
-	mkdir -p $(dir $@) && cat $< | $(KNP) -tab -read-feature > $@ || rm -f $@
+	mkdir -p $(dir $@) && cat $< | $(KNP) -tab -dpnd > $@ || rm -f $@
 
 # add_sems.py
 $(ADD_SEMS_KNPS): $(ADD_SEMS_KNP_DIR)/%.knp: $(ORIG_KNP_DIR)/%.knp

--- a/src/kyoto_reader/scripts/template.mk
+++ b/src/kyoto_reader/scripts/template.mk
@@ -31,9 +31,9 @@ $(ORIG_KNP_DONE): $(CORPUS_KNPS)
 .PHONY: add-feats
 add-feats: $(OUT_KNPS)
 
-# knp -dpnd
+# knp -dpnd -read-feature
 $(OUT_KNPS): $(OUT_KNP_DIR)/%.knp: $(ADD_SEMS_KNP_DIR)/%.knp
-	mkdir -p $(dir $@) && cat $< | $(KNP) -tab -dpnd > $@ || rm -f $@
+	mkdir -p $(dir $@) && cat $< | $(KNP) -tab -dpnd -read-feature > $@ || rm -f $@
 
 # add_sems.py
 $(ADD_SEMS_KNPS): $(ADD_SEMS_KNP_DIR)/%.knp: $(ORIG_KNP_DIR)/%.knp


### PR DESCRIPTION
## What

This PR fixes a bug in the corpus preprocessor, which changes dependency labels.

## Environment
- kyoto-reader: the current HEAD of master (83143747308a968aa32cbb8011d2371fe950cac0)
- Python: 3.8.5
- OS: macOS Bug Sur (11.1)

## To reproduce

```
$ mkdir knp
$ wget https://raw.githubusercontent.com/ku-nlp/KWDLC/master/knp/w201106-00000/w201106-0000060877.knp -O knp/w201106-0000060877.knp
$ mkdir out
$ kyoto configure --corpus-dir $(readlink -f knp) --data-dir $(readlink -f out) --juman-dic-dir $(readlink -f <path/to/JumanDIC>)
$ cd out && make -i && cd ..
$ head -n12 knp/w201106-0000060877.knp  | tail -n1
+ 6D <rel type="=" target="著者"/>
$ head -n12 out/knp/w201106-0000060877.knp | tail -n1
+ 5D <rel type="=" target="著者"/><文節内><係:文節内><地名><括弧始><引用内文頭><体言><名詞項候補><先行詞候補><SM-場所>
```
